### PR TITLE
chore: dead code pass, comment out unreachable code (reversible)

### DIFF
--- a/client/app/components/filter-toolbar/sort-header/sort-header.tsx
+++ b/client/app/components/filter-toolbar/sort-header/sort-header.tsx
@@ -11,41 +11,42 @@ type SortHeaderProps = {
   onChange: (params: SortValue) => void;
 };
 
-export const useSortQueryParams = ({
-  initial = { property: "", isDescending: false },
-}: {
-  initial?: SortValue;
-}) => {
-  const [queryParams, setQueryParams] = useQueryStates({
-    "sort-property": parseAsString.withDefault(initial.property),
-    "sort-isDescending": parseAsBoolean.withDefault(initial.isDescending),
-  });
-
-  const setSortQueryParams = useCallback(
-    (sort: SortValue) => {
-      setQueryParams(() => ({
-        "sort-isDescending": sort.isDescending,
-        "sort-property": sort.property,
-      }));
-    },
-    [setQueryParams],
-  );
-
-  const reset = useCallback(() => {
-    setQueryParams(null);
-  }, [setQueryParams]);
-
-  const sortQueryParams = {
-    property: queryParams["sort-property"],
-    isDescending: queryParams["sort-isDescending"],
-  };
-
-  return {
-    sortQueryParams,
-    setSortQueryParams,
-    reset,
-  };
-};
+// DEADCODE 2026-07-29: no references from main.tsx/router tree or tests; commented pending review
+// export const useSortQueryParams = ({
+//   initial = { property: "", isDescending: false },
+// }: {
+//   initial?: SortValue;
+// }) => {
+//   const [queryParams, setQueryParams] = useQueryStates({
+//     "sort-property": parseAsString.withDefault(initial.property),
+//     "sort-isDescending": parseAsBoolean.withDefault(initial.isDescending),
+//   });
+//
+//   const setSortQueryParams = useCallback(
+//     (sort: SortValue) => {
+//       setQueryParams(() => ({
+//         "sort-isDescending": sort.isDescending,
+//         "sort-property": sort.property,
+//       }));
+//     },
+//     [setQueryParams],
+//   );
+//
+//   const reset = useCallback(() => {
+//     setQueryParams(null);
+//   }, [setQueryParams]);
+//
+//   const sortQueryParams = {
+//     property: queryParams["sort-property"],
+//     isDescending: queryParams["sort-isDescending"],
+//   };
+//
+//   return {
+//     sortQueryParams,
+//     setSortQueryParams,
+//     reset,
+//   };
+// };
 
 export const SortHeader = ({ label, id, value, onChange }: SortHeaderProps) => {
   const Icon = value.isDescending ? ArrowDown : ArrowUp;

--- a/client/app/constants/endpoint.constant.ts
+++ b/client/app/constants/endpoint.constant.ts
@@ -25,6 +25,7 @@ export const API_BASES = {
 
 // ─── OIDC client endpoints (auth-clients-oidc.service) ──────────────────────
 
-export const AUTH_OIDC_ENDPOINTS = {
-  OIDC_TOKEN: `${BLOCKS_IAM_BASE_URL}/api${AUTH_OIDC_SUBPATH}/token`,
-} as const;
+// DEADCODE 2026-07-29: no references in client or e2e; commented pending review
+// export const AUTH_OIDC_ENDPOINTS = {
+//   OIDC_TOKEN: `${BLOCKS_IAM_BASE_URL}/api${AUTH_OIDC_SUBPATH}/token`,
+// } as const;

--- a/client/app/hooks/use-theme.ts
+++ b/client/app/hooks/use-theme.ts
@@ -54,5 +54,6 @@
 // toggle wrote the cookie; on reload the two disagreed (toggle showed Dark but
 // the UI rendered Light). Consolidating on blocks-kit removes that split-brain.
 export { ThemeProvider } from "@seliseblocks/genesis-os/providers";
-export { useTheme } from "@seliseblocks/genesis-os/hooks";
-export type { Theme } from "@seliseblocks/genesis-os/hooks";
+// DEADCODE 2026-07-29: unused re-exports, consumers import useTheme and Theme from the package directly; commented pending review
+// export { useTheme } from "@seliseblocks/genesis-os/hooks";
+// export type { Theme } from "@seliseblocks/genesis-os/hooks";

--- a/client/app/modules/workflow/components/node-inspector/form-builder/fields/conditions-field.tsx
+++ b/client/app/modules/workflow/components/node-inspector/form-builder/fields/conditions-field.tsx
@@ -236,4 +236,5 @@ export const ConditionsField = ({
   );
 };
 
-export default ConditionsField;
+// DEADCODE 2026-07-29: default export has no importers (all consumers use the named export); commented pending review
+// export default ConditionsField;

--- a/client/app/modules/workflow/components/node-inspector/form-builder/fields/fields.ts
+++ b/client/app/modules/workflow/components/node-inspector/form-builder/fields/fields.ts
@@ -52,16 +52,17 @@ export const FIELD_COMPONENTS_REGISTRY: Record<
   "callout-accordion-display": CalloutAccordionDisplayField,
 };
 
-/**
- * Register a custom field component for a specific field type.
- * This allows you to override default field components or add new ones.
- *
- * @param fieldType - The type of field to register
- * @param component - The React component to use for this field type
- */
-export const registerFieldComponent = (
-  fieldType: FormFieldType,
-  component: React.ComponentType<FieldComponentProps<unknown>>,
-) => {
-  FIELD_COMPONENTS_REGISTRY[fieldType] = component;
-};
+// DEADCODE 2026-07-29: extension hook with no callers in client, e2e or tests; commented pending review
+// /**
+//  * Register a custom field component for a specific field type.
+//  * This allows you to override default field components or add new ones.
+//  *
+//  * @param fieldType - The type of field to register
+//  * @param component - The React component to use for this field type
+//  */
+// export const registerFieldComponent = (
+//   fieldType: FormFieldType,
+//   component: React.ComponentType<FieldComponentProps<unknown>>,
+// ) => {
+//   FIELD_COMPONENTS_REGISTRY[fieldType] = component;
+// };

--- a/client/app/modules/workflow/constants/index.ts
+++ b/client/app/modules/workflow/constants/index.ts
@@ -7,7 +7,8 @@ export const getHandleLabel = (handleId?: string | null) => {
   return handleId ? HANDLE_LABELS[handleId] || "" : "";
 };
 
-export const EXECUTION_STATUS_RUNNING = "WF003"
+// DEADCODE 2026-07-29: no references in client or e2e; commented pending review
+// export const EXECUTION_STATUS_RUNNING = "WF003"
 export const EXECUTION_STATUS_COMPLETED = "WF004"
 export const EXECUTION_STATUS_FAILED = "WF005"
 

--- a/client/app/modules/workflow/services/email.services.ts
+++ b/client/app/modules/workflow/services/email.services.ts
@@ -35,4 +35,5 @@ class EmailService {
 }
 
 export const emailService = new EmailService();
-export default EmailService;
+// DEADCODE 2026-07-29: default export has no importers (consumers use the emailService instance); commented pending review
+// export default EmailService;

--- a/client/app/modules/workflow/services/language.manager.service.ts
+++ b/client/app/modules/workflow/services/language.manager.service.ts
@@ -14,4 +14,5 @@ class LanguageManagerService {
 }
 
 export const languageManagerService = new LanguageManagerService();
-export default LanguageManagerService;
+// DEADCODE 2026-07-29: default export has no importers (consumers use the languageManagerService instance); commented pending review
+// export default LanguageManagerService;


### PR DESCRIPTION
## Dead code pass (comment out only, no deletions)

Reversible cleanup: provably unreachable code is commented out with a `DEADCODE 2026-07-29` marker, never deleted. Verified with knip (reachability from `main.tsx` / `router.tsx`), reference greps including test files, a route-by-route grep of every controller action against this repo's `client/` and `e2e/`, and a word-boundary grep of every sibling repo under the Blocks codebase. Build and test results are listed under Verification.

### A. Commented out (8 items)

| Path | What | Why it is dead |
|---|---|---|
| `client/app/components/filter-toolbar/sort-header/sort-header.tsx` | `useSortQueryParams` hook | Sole reference is its own declaration; not used by `SortHeader`, any page, or any test. |
| `client/app/modules/workflow/constants/index.ts` | `EXECUTION_STATUS_RUNNING` | Declaration-only; the sibling COMPLETED/FAILED constants are used, this one is not. |
| `client/app/constants/endpoint.constant.ts` | `AUTH_OIDC_ENDPOINTS` | Declaration-only; the auth-clients-oidc service it was written for does not reference it. |
| `client/app/modules/workflow/components/node-inspector/form-builder/fields/fields.ts` | `registerFieldComponent` | Extension hook with zero callers in client, e2e or tests; the registry it writes to is only populated statically. |
| `client/app/modules/workflow/services/email.services.ts` | `export default EmailService` | No default importers; consumers use the `emailService` instance. |
| `client/app/modules/workflow/services/language.manager.service.ts` | `export default LanguageManagerService` | No default importers; consumers use the `languageManagerService` instance. |
| `client/app/modules/workflow/components/node-inspector/form-builder/fields/conditions-field.tsx` | `export default ConditionsField` | No default importers; barrel, registry and tests all use the named export. |
| `client/app/hooks/use-theme.ts` | `useTheme` / `Theme` re-exports | Consumers import both from `@seliseblocks/genesis-os` directly; only the `ThemeProvider` re-export is used (by `main.tsx`) and it stays live. |

### B. Candidates left for review (not touched)

Backend endpoints (public/auth surface; a clean grep cannot prove absence of external, SDK or service-to-service consumers, so these are listed, never commented):

- `POST Migration/DataCleanup` (`MigrationController.DataCleanup`): zero references in this repo's client and e2e and in every repo under the Blocks codebase.
- `POST Workflow/.../TestWebhook` (`WorkflowController.TestWebhook`): zero word-boundary references anywhere.
- For the record: the `Deployment` and `People` controller actions have no callers in this repo's client, but they are referenced by sibling repos, so they are plainly cross-repo endpoints and were kept without listing each one.

Frontend, ambiguous or convention-driven (knip reports the export keyword unused, but the symbol is used inside its module, by tests, or is a ui-kit/barrel convention; removing the keyword would be an edit rather than a comment-out):

- ui-kit part exports across `app/components/ui-kits/` (dropdown-menu, select, sheet, dialog, card, table, command, toast, alert, breadcrumb, badge, form, button/input/switch/textarea/calendar prop types): shadcn convention exports.
- Service class exports whose singleton instance is the real consumer: `HttpClient`, `WorkflowService`, `AgentService`, `AuthClientsService`.
- Symbols used inside their own module: `FilterToolBarMobileView`, `FilterChangeHandler`, `SortValue`, `ChipsContext`, `NodeInspectorLayouts`, `HANDLE_LABELS`, `WorkflowDetailsContent`, `createWorkflowStore`, `NODE_TYPE_REGISTER`, `resolveDefaultValue`, `LayoutWithTest`, `useTheme` test stub.
- Unused exported types in `app/modules/workflow/types/` and `models/` (agent.service.type.ts, resolved-schema-field.types.ts, data-service.ts, workflow.model.ts, workflow.service.type.ts, email.ts, language.ts): type-only surface, several mirror server DTOs; left for a human pass.
- Barrel exports in `form-builder/fields/index.ts` and `node-schemas/index.ts`: barrel convention, components are imported directly today.

### Verification

- `tsc -b && vite build`: pass
- `dotnet build Blocks.slnx`: pass
- Backend unit suite (`XUnitTest`): 1361 passed, 0 failed
- Frontend unit suite (`vitest run`): 637 passed, 0 failed (68 files)
- Playwright e2e: 5 workflow specs fail identically with and without this diff (strict-mode locator violation, `getByRole('button', { name: 'Development' })` resolves to 3 elements on the shared dev environment), 2 skipped, login setup passes. The failures pre-date this change: rerunning the same specs with the diff stashed reproduces the identical 5 failures on the clean tree.
- `git diff`: comment additions only, zero deletions, no reachable-code change
